### PR TITLE
添加随机数

### DIFF
--- a/Object/Builtins.vb
+++ b/Object/Builtins.vb
@@ -638,6 +638,32 @@ Public Class Builtins
                                                                 End If
 
                                                                 Return Obj_Nothing
+                                                            End Function}},
+        {"random", New Fox_Builtin With {.BuiltinFunction = Function(args As IEnumerable(Of Object))
+                                                                Dim 所需实参数 = 2
+
+                                                                If args.Count > 所需实参数 Then
+                                                                    Return ThrowError($"实参过多")
+                                                                End If
+
+                                                                If args.Count = 所需实参数 AndAlso args(0) IsNot Nothing Then
+                                                                    If args(0).Type() <> ObjectType.INTEGER_OBJ Then
+                                                                        Return ThrowError($"类型错误: 在参数{1} 中传入了一个{args(0).Type}类型的参数")
+                                                                    ElseIf args(1).Type() <> ObjectType.INTEGER_OBJ Then
+                                                                        Return ThrowError($"类型错误: 在参数{2} 中传入了一个{args(1).Type}类型的参数")
+                                                                    End If
+                                                                    If args(1).Value < args(0).Value Then
+                                                                        Return ThrowError($"参数{1}必须小于等于参数{2}")
+                                                                    End If
+                                                                    Dim val As BigInteger = Utils.GenerateRandomBigInteger(args(0).Value, args(1).Value)
+                                                                    Return New Fox_Integer With {.Value = val}
+                                                                End If
+
+                                                                If args.Count < 所需实参数 Then
+                                                                    Return ThrowError($"提供的实参过少 实参{args.Count}个 形参{所需实参数}个")
+                                                                End If
+
+                                                                Return Nothing
                                                             End Function}}
     }
     Public Shared builtinVars As New Dictionary(Of String, Fox_Builtin) From

--- a/Utils.vb
+++ b/Utils.vb
@@ -1,12 +1,14 @@
 ﻿Imports System.IO
 Imports FoxScript.Utils
 Imports FoxScript.CannotFindCustomErrorException
+Imports System.Numerics
+Imports System.Security.Cryptography
 
 
 Public Class ErrorUtils
 
-        '判断是否为Error对象. 返回一个布尔值
-        Public Shared Function IsError(obj As Fox_Object)
+    '判断是否为Error对象. 返回一个布尔值
+    Public Shared Function IsError(obj As Fox_Object)
         If obj Is Nothing Then Return False
         Return obj.Type = ObjectType.ERROR_OBJ OrElse obj.Type = ObjectType.CUSTOM_ERROR_OBJ
     End Function
@@ -168,6 +170,28 @@ Public Class Utils
         Next
 
         Return Nothing
+    End Function
+
+    Public Shared Function GenerateRandomBigInteger(min As BigInteger, max As BigInteger) As BigInteger
+        ' 计算min和max之间的差值
+        Dim range As BigInteger = max - min
+
+        ' 计算需要多少位来表示范围
+        Dim bits As Integer = CInt(Math.Ceiling(BigInteger.Log(range, 2)))
+
+        ' 创建一个RNGCryptoServiceProvider实例
+        Using rng As RNGCryptoServiceProvider = New RNGCryptoServiceProvider()
+            Dim bytes As Byte() = New Byte(bits / 8) {}
+            Dim result As BigInteger
+
+            Do
+                rng.GetBytes(bytes)
+                ' 将字节数组转换为BigInteger，并减去min以得到正确的范围
+                result = New BigInteger(bytes) Mod (range + 1)
+            Loop While result < 0 ' 确保结果为非负数
+
+            Return result + min
+        End Using
     End Function
 End Class
 

--- a/bin/Debug/includes/Math.Fox
+++ b/bin/Debug/includes/Math.Fox
@@ -7,7 +7,7 @@ Func Abs(x)
     else
         return x
     endif
-
+    
     if x == 0 then
         return x
     endif
@@ -36,3 +36,27 @@ Func Min(x, y)
         return y
     endif
 EndFunc
+
+Func Pow(x, y)
+    if y < 0 then
+        return 1.0 / Pow(x, Abs(y))
+    endif
+
+    dim temp = x
+    For n In range(y - 1)
+        temp = temp * x
+    Next
+    return temp
+EndFunc
+
+Class Random
+	Func Next(min, max)
+        return random(min, max)
+    EndFunc
+
+    Func NextFloat(min, max)
+        dim i = random(min, max)
+        dim j = random(0, 10000000) / 10000000.0
+        return i + j
+    EndFunc
+EndClass


### PR DESCRIPTION
如题，添加了一个系统函数random(min, max)用于生成整数
在Math.fox中添加了Pow(x, y)（指数）（顺带）和Random类，Random类包含函数Next(min, max)（直接调用random）和NextFloat(min, max)（生成一个随机小数）
``` Fox Script
>>> random(1, 100)
55
>>> random(1, 100)
87
>>> random(1, 10000000000000000)
1473789437881806
>>> Math.Pow(3, 3)
27
>>> Math.Pow(3, -2)
0.1111111111111111111111111111
>>> Math.Random.Next(3, -2)
Error: 参数1必须小于等于参数2
>>> Math.Random.Next(-8, -2)
-8
>>> Math.Random.NextFloat(8, 14)
8.4902007
>>> Math.Random.NextFloat(8, 14)
9.1496909
```
(第二次pr)